### PR TITLE
Fix Windows console UTF-8 output by setting console code page

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,4 @@
+#include <windows.h>
 #include "algorithms.h"
 #include "cmdparser.h"
 #include <inttypes.h>
@@ -7,6 +8,7 @@
 #include <string.h>
 
 int main(int argc, char **argv) {
+  SetConsoleOutputCP(CP_UTF8);
   int help_flag = 0;
   char *fib_value = NULL;
   char *basic_value = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,6 @@
+#ifdef _WIN32
 #include <windows.h>
+#endif
 #include "algorithms.h"
 #include "cmdparser.h"
 #include <inttypes.h>
@@ -8,7 +10,9 @@
 #include <string.h>
 
 int main(int argc, char **argv) {
+  #ifdef _WIN32
   SetConsoleOutputCP(CP_UTF8);
+  #endif
   int help_flag = 0;
   char *fib_value = NULL;
   char *basic_value = NULL;


### PR DESCRIPTION
Fixes the issue with incorrect display of UTF-8 characters (such as '≈') in the Windows console when running the utility.